### PR TITLE
Update .gitignore to exclude directory generated during set-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ buildInfo.json
 
 #Debian Pkg
 *.deb
+
+# Temporary directory for download
+.tmp/


### PR DESCRIPTION
The directory named ".tmp" is generated during development environment set up procedures. It might be good to exclude the directory from the repository.