### PR TITLE
Remove redundancy in package version string

### DIFF
--- a/makePkg.py
+++ b/makePkg.py
@@ -84,12 +84,10 @@ if __name__ == '__main__':
     cfgFile.close()
     firstBuild = True
     buildTargetList = parsedPkgInfo['platforms']
-    pkgVersion = usrName + '_' + parsedPkgInfo['major']+ '.'\
-                  + parsedPkgInfo['minor'] +  '.' + parsedPkgInfo['patch'] + \
-                  '.' + parsedPkgInfo['build'] + '.' + parsedPkgInfo['changeindex']
     pkgVersionNum = parsedPkgInfo['major']+ '.'\
                   + parsedPkgInfo['minor'] +  '.' + parsedPkgInfo['patch'] + \
                   '.' + parsedPkgInfo['build'] + '.' + parsedPkgInfo['changeindex']
+    pkgVersion = usrName + '_' + pkgVersionNum
     build_dir = "flexswitch-" + pkgVersion
     command = [
             'rm -rf ' + build_dir,


### PR DESCRIPTION
`pkgVersionNum` and `pkgVersion` include a common string. It might help to reduce the effort when the version representation changes.