### PR TITLE
Simplify concatenation of a list of strings

### DIFF
--- a/codegentools/dbif/dbif.go
+++ b/codegentools/dbif/dbif.go
@@ -699,13 +699,13 @@ func generateUnmarshalFcn(listingsFd *os.File, objFileBase string, dirStore stri
 		                if field.CanSet() {
 		                        switch field.Kind() {
 		                        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		                                i, _ := strconv.ParseInt(val[0], 10, 64) 
+		                                i, _ := strconv.ParseInt(val[0], 10, 64)
 		                                field.SetInt(i)
 		                        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		                                ui, _ := strconv.ParseUint(val[0], 10, 64) 
+		                                ui, _ := strconv.ParseUint(val[0], 10, 64)
 		                                field.SetUint(ui)
 		                        case reflect.Float64:
-		                                f, _ := strconv.ParseFloat(val[0], 64) 
+		                                f, _ := strconv.ParseFloat(val[0], 64)
 		                                field.SetFloat(f)
 		                        case reflect.Bool:
 		                                b, _ := strconv.ParseBool(val[0])
@@ -715,7 +715,7 @@ func generateUnmarshalFcn(listingsFd *os.File, objFileBase string, dirStore stri
 		                        }
 		                }
 		        }
-		        return retObj, nil 
+		        return retObj, nil
 		}
 		`)
 		}
@@ -741,9 +741,7 @@ func generateUnmarshalFcn(listingsFd *os.File, objFileBase string, dirStore stri
 			)`)
 		}
 
-		for _, marshalLine := range marshalFcnsLine {
-			marshalFcnFd.WriteString(string(marshalLine))
-		}
+		marshalFcnFd.WriteString(strings.Join(marshalFcnsLine, ""))
 	}
 	return nil
 }


### PR DESCRIPTION
- for-range loop is replaced by strings.Join()
- Trailing white spaces are removed by gofmt

