### PR TITLE
Pull regex compilation out of loop for performance

### DIFF
--- a/codegentools/dbif/dbif.go
+++ b/codegentools/dbif/dbif.go
@@ -351,20 +351,15 @@ func getObjectMemberInfo(objMap map[string]ObjectInfoJson, objName string) (memb
 	return membersInfo
 }
 
+var reg = regexp.MustCompile("[`\"]")
+var alphas = regexp.MustCompile("[^A-Za-z]")
+
 func getSpecialTagsForAttribute(attrTags string, attrInfo *ObjectMembersInfo) {
-	reg, err := regexp.Compile("[`\"]")
-	if err != nil {
-		fmt.Println("Error in regex ", err)
-	}
 	tags := reg.ReplaceAllString(attrTags, "")
 	splits := strings.Split(tags, ",")
 	for _, part := range splits {
 		keys := strings.Split(part, ":")
 		for idx, key := range keys {
-			alphas, err := regexp.Compile("[^A-Za-z]")
-			if err != nil {
-				fmt.Println("Error in regex ", err)
-			}
 			key = alphas.ReplaceAllString(key, "")
 			switch key {
 			case "SNAPROUTE":


### PR DESCRIPTION
There are regex compilations in a loop, which are not light operations. Pulling them out is better for performance.

In addition to that, we know the regular expressions never fail to compile, thus we can use `regexp.MustCompile()`.