### PR TITLE
Use filepath.Join() to concatenate strings when creating a path

### DIFF
--- a/codegentools/dbif/dbif.go
+++ b/codegentools/dbif/dbif.go
@@ -75,7 +75,7 @@ func main() {
 	//
 	// Create a directory to store all the temporary files
 	//
-	dirStore := filepath.Join(base, "/reltools/codegentools/._genInfo/")
+	dirStore := filepath.Join(base, "reltools/codegentools/._genInfo")
 	//os.Mkdir(dirStore, 0777)
 	listingFile := filepath.Join(dirStore, "generatedGoFiles.txt")
 
@@ -96,7 +96,7 @@ func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File,
 	// However in some cases we have only go objects. Read the goObjInfo.json file and generate a similar
 	// structure here.
 	//
-	goObjSources := filepath.Join(base, "/snaproute/src/models/objects/goObjInfo.json")
+	goObjSources := filepath.Join(base, "snaproute/src/models/objects/goObjInfo.json")
 
 	bytes, err := ioutil.ReadFile(goObjSources)
 	if err != nil {
@@ -109,12 +109,12 @@ func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File,
 		fmt.Printf("Error in unmarshaling data from ", goObjSources, err)
 	}
 
-	objFileBase := filepath.Join(base, "/snaproute/src/models/objects/")
+	objFileBase := filepath.Join(base, "snaproute/src/models/objects")
 	for goSrcFile, ownerName := range goSrcsMap {
 		generateHandCodedObjectsInformation(listingsFd, objFileBase, goSrcFile, ownerName.Owner)
 	}
 
-	objJsonFile := filepath.Join(base, "/snaproute/src/models/objects/genObjectConfig.json")
+	objJsonFile := filepath.Join(base, "snaproute/src/models/objects/genObjectConfig.json")
 	bytes, err = ioutil.ReadFile(objJsonFile)
 	if err != nil {
 		fmt.Println("Error in reading Object json file", objJsonFile)
@@ -193,7 +193,7 @@ func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File,
 }
 
 func processActionObjects(fset *token.FileSet, base string, listingsFd *os.File, dirStore string) {
-	goActionSources := filepath.Join(base, "/snaproute/src/models/actions/goActionInfo.json")
+	goActionSources := filepath.Join(base, "snaproute/src/models/actions/goActionInfo.json")
 
 	bytes, err := ioutil.ReadFile(goActionSources)
 	if err != nil {
@@ -206,12 +206,12 @@ func processActionObjects(fset *token.FileSet, base string, listingsFd *os.File,
 		fmt.Printf("Error in unmarshaling data from ", goActionSources, err)
 	}
 
-	actionFileBase := filepath.Join(base, "/snaproute/src/models/actions/")
+	actionFileBase := filepath.Join(base, "snaproute/src/models/actions")
 	for goSrcFile, ownerName := range goActionSrcsMap {
 		generateHandCodedActionsInformation(listingsFd, actionFileBase, goSrcFile, ownerName.Owner)
 	}
 
-	actionJsonFile := filepath.Join(base, "/snaproute/src/models/actions/genObjectAction.json")
+	actionJsonFile := filepath.Join(base, "snaproute/src/models/actions/genObjectAction.json")
 	bytes, err = ioutil.ReadFile(actionJsonFile)
 	if err != nil {
 		fmt.Println("Error in reading Object action json file", actionJsonFile)
@@ -313,7 +313,7 @@ func getObjectMemberInfo(objMap map[string]ObjectInfoJson, objName string) (memb
 		fmt.Println(" Environment Variable SR_CODE_BASE has not been set")
 		return membersInfo
 	}
-	objFileBase := filepath.Join(base, "/snaproute/src/models/objects")
+	objFileBase := filepath.Join(base, "snaproute/src/models/objects")
 	for name, obj := range objMap {
 		if objName == name {
 			obj.ObjName = name

--- a/codegentools/dbif/dbif.go
+++ b/codegentools/dbif/dbif.go
@@ -90,12 +90,6 @@ func main() {
 }
 
 func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File, dirStore string) {
-	var goSrcsMap map[string]RawObjSrcInfo
-	var objMap map[string]ObjectInfoJson
-
-	objJsonFile := base + "/snaproute/src/models/objects/genObjectConfig.json"
-	objFileBase := base + "/snaproute/src/models/objects/"
-
 	//
 	// Files generated from yang models are already listed in right format in genObjectConfig.json
 	// However in some cases we have only go objects. Read the goObjInfo.json file and generate a similar
@@ -108,20 +102,24 @@ func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File,
 		fmt.Println("Error in reading Object configuration file", goObjSources)
 		return
 	}
+	var goSrcsMap map[string]RawObjSrcInfo
 	err = json.Unmarshal(bytes, &goSrcsMap)
 	if err != nil {
 		fmt.Printf("Error in unmarshaling data from ", goObjSources, err)
 	}
 
+	objFileBase := base + "/snaproute/src/models/objects/"
 	for goSrcFile, ownerName := range goSrcsMap {
 		generateHandCodedObjectsInformation(listingsFd, objFileBase, goSrcFile, ownerName.Owner)
 	}
 
+	objJsonFile := base + "/snaproute/src/models/objects/genObjectConfig.json"
 	bytes, err = ioutil.ReadFile(objJsonFile)
 	if err != nil {
 		fmt.Println("Error in reading Object json file", objJsonFile)
 		return
 	}
+	var objMap map[string]ObjectInfoJson
 	err = json.Unmarshal(bytes, &objMap)
 	if err != nil {
 		fmt.Printf("Error in unmarshaling data from ", objJsonFile, err)
@@ -194,11 +192,6 @@ func processConfigObjects(fset *token.FileSet, base string, listingsFd *os.File,
 }
 
 func processActionObjects(fset *token.FileSet, base string, listingsFd *os.File, dirStore string) {
-	var actionMap map[string]ObjectInfoJson
-	var goActionSrcsMap map[string]RawObjSrcInfo
-
-	actionJsonFile := base + "/snaproute/src/models/actions/genObjectAction.json"
-	actionFileBase := base + "/snaproute/src/models/actions/"
 	goActionSources := base + "/snaproute/src/models/actions/goActionInfo.json"
 
 	bytes, err := ioutil.ReadFile(goActionSources)
@@ -206,20 +199,24 @@ func processActionObjects(fset *token.FileSet, base string, listingsFd *os.File,
 		fmt.Println("Error in reading action object file", goActionSources)
 		return
 	}
+	var goActionSrcsMap map[string]RawObjSrcInfo
 	err = json.Unmarshal(bytes, &goActionSrcsMap)
 	if err != nil {
 		fmt.Printf("Error in unmarshaling data from ", goActionSources, err)
 	}
 
+	actionFileBase := base + "/snaproute/src/models/actions/"
 	for goSrcFile, ownerName := range goActionSrcsMap {
 		generateHandCodedActionsInformation(listingsFd, actionFileBase, goSrcFile, ownerName.Owner)
 	}
 
+	actionJsonFile := base + "/snaproute/src/models/actions/genObjectAction.json"
 	bytes, err = ioutil.ReadFile(actionJsonFile)
 	if err != nil {
 		fmt.Println("Error in reading Object action json file", actionJsonFile)
 		return
 	}
+	var actionMap map[string]ObjectInfoJson
 	err = json.Unmarshal(bytes, &actionMap)
 	if err != nil {
 		fmt.Printf("Error in unmarshaling data from ", actionJsonFile, err)
@@ -462,9 +459,6 @@ func generateMembersInfoForAllObjects(str *ast.StructType, objJsonFileName strin
 }
 
 func generateHandCodedObjectsInformation(listingsFd *os.File, objFileBase string, srcFile string, owner string) error {
-	var objMap map[string]ObjectInfoJson
-	objMap = make(map[string]ObjectInfoJson, 1)
-
 	// First read the existing objects
 	genObjInfoFile := objFileBase + "genObjectConfig.json"
 
@@ -473,6 +467,8 @@ func generateHandCodedObjectsInformation(listingsFd *os.File, objFileBase string
 		fmt.Println("Error in reading Object configuration file", genObjInfoFile)
 		return err
 	}
+
+	objMap := make(map[string]ObjectInfoJson, 1)
 	err = json.Unmarshal(bytes, &objMap)
 	if err != nil {
 		fmt.Printf("Error in unmarshaling data from ", genObjInfoFile, err)
@@ -553,12 +549,10 @@ func generateHandCodedObjectsInformation(listingsFd *os.File, objFileBase string
 }
 
 func generateHandCodedActionsInformation(listingsFd *os.File, actionFileBase string, srcFile string, owner string) error {
-	var actionMap map[string]ObjectInfoJson
-	actionMap = make(map[string]ObjectInfoJson, 1)
-
 	// First read the existing objects
 	genActionInfoFile := actionFileBase + "genObjectAction.json"
 
+	actionMap := make(map[string]ObjectInfoJson, 1)
 	bytes, err := ioutil.ReadFile(genActionInfoFile)
 	if err == nil {
 		err = json.Unmarshal(bytes, &actionMap)
@@ -694,13 +688,13 @@ func generateUnmarshalFcn(listingsFd *os.File, objFileBase string, dirStore stri
 		                if field.CanSet() {
 		                        switch field.Kind() {
 		                        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		                                i, _ := strconv.ParseInt(val[0], 10, 64) 
+		                                i, _ := strconv.ParseInt(val[0], 10, 64)
 		                                field.SetInt(i)
 		                        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		                                ui, _ := strconv.ParseUint(val[0], 10, 64) 
+		                                ui, _ := strconv.ParseUint(val[0], 10, 64)
 		                                field.SetUint(ui)
 		                        case reflect.Float64:
-		                                f, _ := strconv.ParseFloat(val[0], 64) 
+		                                f, _ := strconv.ParseFloat(val[0], 64)
 		                                field.SetFloat(f)
 		                        case reflect.Bool:
 		                                b, _ := strconv.ParseBool(val[0])
@@ -710,7 +704,7 @@ func generateUnmarshalFcn(listingsFd *os.File, objFileBase string, dirStore stri
 		                        }
 		                }
 		        }
-		        return retObj, nil 
+		        return retObj, nil
 		}
 		`)
 		}

--- a/codegentools/dbif/jsonSchema.go
+++ b/codegentools/dbif/jsonSchema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 type KeyInfo struct {
@@ -122,7 +123,7 @@ func genJsonSchema(dirStore string, objectsByOwner map[string][]ObjectInfoJson) 
 			if obj.Access == "x" {
 				continue
 			}
-			jsonFileName := dirStore + obj.ObjName + MEMBER_JSON
+			jsonFileName := filepath.Join(dirStore, obj.ObjName+MEMBER_JSON)
 			bytes, err := ioutil.ReadFile(jsonFileName)
 			if err != nil {
 				fmt.Println("Error in reading Object configuration file", jsonFileName,
@@ -139,7 +140,7 @@ func genJsonSchema(dirStore string, objectsByOwner map[string][]ObjectInfoJson) 
 			ovsTables[obj.ObjName] = table
 		}
 		jsonSchema.Tables = ovsTables
-		extSchemaFile := dirStore + owner + ".extschema"
+		extSchemaFile := filepath.Join(dirStore, owner+".extschema")
 		writeJson(extSchemaFile, jsonSchema)
 	}
 }


### PR DESCRIPTION
This pull request has to be reviewed after merging #26 because this follows #26.

filepath.Join() would be suitable for platform independent path manipulation rather than concatenating with "+".